### PR TITLE
Add RakutenClient for API interactions and implement unit tests

### DIFF
--- a/apps/batch/etl/clients/rakuten_client.py
+++ b/apps/batch/etl/clients/rakuten_client.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+class RakutenClientError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RakutenClientConfig:
+    application_id: str
+    affiliate_id: Optional[str]
+    timeout_sec: float = 10.0
+    max_attempts: int = 5
+    base_backoff_sec: float = 1.0
+
+
+class RakutenClient:
+    def __init__(self, *, config: RakutenClientConfig) -> None:
+        self._config = config
+
+    def fetch_ranking(self, *, genre_id: int) -> Mapping[str, Any]:
+        return self._get_json(
+            endpoint="https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601",
+            params={"genreId": genre_id},
+        )
+
+    def fetch_item(self, *, item_code: str) -> Mapping[str, Any]:
+        return self._get_json(
+            endpoint="https://app.rakuten.co.jp/services/api/IchibaItem/Search/20220601",
+            params={"itemCode": item_code, "hits": 1, "page": 1},
+        )
+
+    def fetch_genre(self, *, genre_id: int) -> Mapping[str, Any]:
+        return self._get_json(
+            endpoint="https://app.rakuten.co.jp/services/api/IchibaGenre/Search/20140222",
+            params={"genreId": genre_id},
+        )
+
+    def fetch_tag(self, *, tag_id: int) -> Mapping[str, Any]:
+        return self._get_json(
+            endpoint="https://app.rakuten.co.jp/services/api/IchibaTag/Search/20140222",
+            params={"tagId": tag_id},
+        )
+
+    def _get_json(self, *, endpoint: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        base_params = {
+            "applicationId": self._config.application_id,
+            "format": "json",
+            "formatVersion": 2,
+        }
+        if self._config.affiliate_id:
+            base_params["affiliateId"] = self._config.affiliate_id
+
+        merged_params = {**base_params, **params}
+        query = urllib.parse.urlencode(merged_params)
+        url = f"{endpoint}?{query}"
+
+        for attempt in range(1, self._config.max_attempts + 1):
+            try:
+                with urllib.request.urlopen(url, timeout=self._config.timeout_sec) as res:
+                    payload = res.read().decode("utf-8")
+                    return json.loads(payload)
+            except urllib.error.HTTPError as exc:
+                status = exc.code
+                if status in (401, 403):
+                    raise RakutenClientError(f"Rakuten API auth error: {status}") from exc
+                if status == 429 or 500 <= status < 600:
+                    self._sleep_backoff(exc.headers.get("Retry-After"), attempt)
+                    continue
+                raise RakutenClientError(f"Rakuten API error: {status}") from exc
+            except urllib.error.URLError as exc:
+                self._sleep_backoff(None, attempt)
+                continue
+
+        raise RakutenClientError("Rakuten API retries exhausted")
+
+    def _sleep_backoff(self, retry_after: Optional[str], attempt: int) -> None:
+        if retry_after:
+            try:
+                delay = float(retry_after)
+            except ValueError:
+                delay = self._config.base_backoff_sec * (2 ** (attempt - 1))
+        else:
+            delay = self._config.base_backoff_sec * (2 ** (attempt - 1))
+        time.sleep(delay)

--- a/apps/batch/etl/tests/unit/test_rakuten_client.py
+++ b/apps/batch/etl/tests/unit/test_rakuten_client.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import io
+import sys
+from email.message import Message
+from pathlib import Path
+from unittest import mock
+import urllib.error
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from clients.rakuten_client import (  # noqa: E402
+    RakutenClient,
+    RakutenClientConfig,
+    RakutenClientError,
+)
+
+
+def _make_response(payload: str) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.read.return_value = payload.encode("utf-8")
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+@pytest.mark.unit
+def test_fetch_item_success_returns_json() -> None:
+    client = RakutenClient(
+        config=RakutenClientConfig(application_id="app", affiliate_id=None)
+    )
+    response = _make_response('{"items":[{"itemCode":"shop:1"}]}')
+
+    with mock.patch("urllib.request.urlopen", return_value=response):
+        result = client.fetch_item(item_code="shop:1")
+
+    assert result["items"][0]["itemCode"] == "shop:1"
+
+
+@pytest.mark.unit
+def test_fetch_ranking_raises_on_auth_error() -> None:
+    client = RakutenClient(
+        config=RakutenClientConfig(application_id="app", affiliate_id=None)
+    )
+    error = urllib.error.HTTPError(
+        url="http://example",
+        code=401,
+        msg="Unauthorized",
+        hdrs=Message(),
+        fp=io.BytesIO(),
+    )
+
+    with mock.patch("urllib.request.urlopen", side_effect=error):
+        with pytest.raises(RakutenClientError):
+            client.fetch_ranking(genre_id=1)
+
+
+@pytest.mark.unit
+def test_fetch_tag_retries_on_429_then_succeeds() -> None:
+    client = RakutenClient(
+        config=RakutenClientConfig(
+            application_id="app",
+            affiliate_id=None,
+            max_attempts=3,
+            base_backoff_sec=0.0,
+        )
+    )
+    headers = Message()
+    headers["Retry-After"] = "0"
+    error = urllib.error.HTTPError(
+        url="http://example",
+        code=429,
+        msg="Too Many Requests",
+        hdrs=headers,
+        fp=io.BytesIO(),
+    )
+    response = _make_response('{"items":[{"tagId":1}]}')
+
+    with mock.patch("urllib.request.urlopen", side_effect=[error, response]) as mocked:
+        with mock.patch("time.sleep") as sleeper:
+            result = client.fetch_tag(tag_id=1)
+
+    assert result["items"][0]["tagId"] == 1
+    assert mocked.call_count == 2
+    sleeper.assert_called()
+
+
+@pytest.mark.unit
+def test_fetch_genre_retries_then_exhausts() -> None:
+    client = RakutenClient(
+        config=RakutenClientConfig(
+            application_id="app",
+            affiliate_id=None,
+            max_attempts=2,
+            base_backoff_sec=0.0,
+        )
+    )
+    error = urllib.error.URLError("timeout")
+
+    with mock.patch("urllib.request.urlopen", side_effect=error):
+        with mock.patch("time.sleep"):
+            with pytest.raises(RakutenClientError):
+                client.fetch_genre(genre_id=1)


### PR DESCRIPTION
Introduce RakutenClient to handle API requests for fetching item rankings, details, genres, and tags from the Rakuten API. Implement error handling for authentication and rate limiting. Add unit tests to validate functionality and error scenarios, ensuring robust performance and reliability.