### PR TITLE
Add ItemTagRepo and unit tests for item tag synchronization

### DIFF
--- a/apps/batch/etl/repos/apl/item_tag_repo.py
+++ b/apps/batch/etl/repos/apl/item_tag_repo.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+
+class Cursor(Protocol):
+    def execute(self, query: str, params: Sequence[object] | None = None) -> None: ...
+    def executemany(self, query: str, params_seq: Sequence[Sequence[object]]) -> None: ...
+    @property
+    def rowcount(self) -> int: ...
+    def close(self) -> None: ...
+
+
+class Connection(Protocol):
+    def cursor(self) -> Cursor: ...
+    def commit(self) -> None: ...
+
+
+class ItemTagRepo:
+    def __init__(self, *, conn: Connection) -> None:
+        self._conn = conn
+
+    def sync_item_tags(self, *, item_id: str, rakuten_tag_ids: Sequence[int]) -> int:
+        delete_sql = "delete from apl.item_tag where item_id = %s"
+        insert_sql = (
+            "insert into apl.item_tag (item_id, rakuten_tag_id) "
+            "values (%s, %s) "
+            "on conflict (item_id, rakuten_tag_id) do nothing"
+        )
+        cur = self._conn.cursor()
+        try:
+            cur.execute(delete_sql, (item_id,))
+            if rakuten_tag_ids:
+                params = [(item_id, tag_id) for tag_id in rakuten_tag_ids]
+                cur.executemany(insert_sql, params)
+                affected = cur.rowcount
+            else:
+                affected = 0
+        finally:
+            cur.close()
+        self._conn.commit()
+        return affected

--- a/apps/batch/etl/tests/unit/test_item_tag_repo.py
+++ b/apps/batch/etl/tests/unit/test_item_tag_repo.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from repos.apl.item_tag_repo import ItemTagRepo  # noqa: E402
+
+
+class FakeCursor:
+    def __init__(self) -> None:
+        self.executed = []
+        self.executed_many = []
+        self.rowcount = 0
+        self.closed = False
+
+    def execute(self, query: str, params=None) -> None:
+        self.executed.append((query, params))
+
+    def executemany(self, query: str, params_seq) -> None:
+        self.executed_many.append((query, params_seq))
+        self.rowcount = len(params_seq)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self, cursor: FakeCursor) -> None:
+        self._cursor = cursor
+        self.committed = False
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+@pytest.mark.unit
+def test_sync_item_tags_deletes_and_inserts() -> None:
+    cursor = FakeCursor()
+    repo = ItemTagRepo(conn=FakeConnection(cursor))
+
+    affected = repo.sync_item_tags(item_id="item-id", rakuten_tag_ids=[1, 2, 3])
+
+    assert affected == 3
+    assert cursor.executed
+    assert "delete from apl.item_tag" in cursor.executed[0][0]
+    assert cursor.executed_many
+
+
+@pytest.mark.unit
+def test_sync_item_tags_handles_empty_tags() -> None:
+    cursor = FakeCursor()
+    repo = ItemTagRepo(conn=FakeConnection(cursor))
+
+    affected = repo.sync_item_tags(item_id="item-id", rakuten_tag_ids=[])
+
+    assert affected == 0
+    assert cursor.executed
+    assert cursor.executed_many == []


### PR DESCRIPTION
- Implemented ItemTagRepo class to manage item tag synchronization with methods to delete existing tags and insert new ones.
- Added unit tests to validate the functionality of sync_item_tags method, including scenarios for handling empty tag lists and verifying database interactions using mock connections.