### PR TITLE
Add GitHub Actions workflow for automatic PR creation

### DIFF
--- a/.github/workflows/auto_create_pr.yaml
+++ b/.github/workflows/auto_create_pr.yaml
@@ -1,0 +1,38 @@
+name: Auto Create Pull Request
+
+on:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-pr:
+    if: github.ref_type == 'branch' && github.ref_name != github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create PR when missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          HEAD_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          existing_count=$(gh pr list --head "${HEAD_BRANCH}" --state open --json number --jq 'length')
+          if [ "${existing_count}" -gt 0 ]; then
+            echo "PR already exists for ${HEAD_BRANCH}. Skipping."
+            exit 0
+          fi
+
+          gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${HEAD_BRANCH}" \
+            --title "Auto PR: ${HEAD_BRANCH}" \
+            --body "Auto-created PR for branch ${HEAD_BRANCH}."


### PR DESCRIPTION
- Introduced a new workflow that automatically creates a pull request for branches that are not the default branch when pushed.
- The workflow checks for existing open PRs before creating a new one to avoid duplicates.